### PR TITLE
Change options on package: acronym

### DIFF
--- a/preambel/preambel.tex
+++ b/preambel/preambel.tex
@@ -742,8 +742,6 @@
 ]{nomencl}[2005/09/22]
 
 \usepackage[
-	footnote,	% Full names appear in the footnote
-	smaller,		% Print acronym in smaller fontsize
 	printonlyused %
 ]{acronym}
 


### PR DESCRIPTION
Changes:

* Do not print acronyms in smaller font size. Did always look weird to have all caps in a slightly smaller font size than regular text
* Do not print as footprint only. Instead, write the full acronym first and introduce the abbreviation in brackets, e.g. Integrated Development Environment (IDE)